### PR TITLE
fix: [BUG-0001] Fixing Defaults for Variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -9,11 +9,11 @@ variable "domain_name" {
 variable "acm_alternative_domain_list" {
   type        = map(string)
   description = "Creates ACM certs based off of how many ACM"
-  default = []
+  default = {}
 }
 
 variable "tag_list" {
   type        = map(any)
   description = "Pass in a set of tags to give the various resources."
-  default = []
+  default = {}
 }


### PR DESCRIPTION
I mistakenly used the wrong symbols when making the variable defaults. I swapped them to the correct ones. 