### PR TITLE
fix: [BUG-0002] Fixing Sub Domain ACM Generation and Validation

### DIFF
--- a/modules/acm_cert_with_validation/main.tf
+++ b/modules/acm_cert_with_validation/main.tf
@@ -1,0 +1,42 @@
+variable "domain_name" {
+    type = string
+}
+
+variable "tag_list" {
+  type = map(string)
+}
+
+variable "zone_id" {
+  type = string
+}
+
+resource "aws_acm_certificate" "acm_certificate" {
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tag_list
+}
+
+# Add to the validation via DNS.
+resource "aws_route53_record" "acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.acm_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = var.zone_id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "root_domain_zone_id" {
-    description = "Root domain zone id."
-    value = aws_route53_zone.zone.zone_id
+  description = "Root domain zone id."
+  value       = aws_route53_zone.zone.zone_id
 }
 
 output "root_domain_deligation_set" {
-    description = "Dedicated set of name servers if you want to reuse them."
-    value = aws_route53_delegation_set.delset
+  description = "Dedicated set of name servers if you want to reuse them."
+  value       = aws_route53_delegation_set.delset
 }
 
 output "root_domain_certificate" {
-    description = "Created domain certificate for the root."
-    value = aws_acm_certificate.domain_acm_certificate
+  description = "Created domain certificate for the root."
+  value       = module.domain_acm
 }
 
 output "alternative_domain_certificates" {
-    description = "An array of objects that houses any alternative domains."
-    value = aws_acm_certificate.alternative_acm_certificates
+  description = "An array of objects that houses any alternative domains."
+  value       = module.alternative_acm
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,9 +7,9 @@ variable "domain_name" {
 # Once given, this would then need to be looped over to generate the cert resource
 # and create the validation records.
 variable "acm_alternative_domain_list" {
-  type        = map(string)
+  type        = list
   description = "Creates ACM certs based off of how many ACM"
-  default = {}
+  default = []
 }
 
 variable "tag_list" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "domain_name" {
 # Once given, this would then need to be looped over to generate the cert resource
 # and create the validation records.
 variable "acm_alternative_domain_list" {
-  type        = list
+  type        = set(string)
   description = "Creates ACM certs based off of how many ACM"
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,11 +9,11 @@ variable "domain_name" {
 variable "acm_alternative_domain_list" {
   type        = set(string)
   description = "Creates ACM certs based off of how many ACM"
-  default = []
+  default     = []
 }
 
 variable "tag_list" {
   type        = map(any)
   description = "Pass in a set of tags to give the various resources."
-  default = {}
+  default     = {}
 }


### PR DESCRIPTION
This is a common pattern apparently, but I've decided to make this my own thing. So what I've done is move the ACM and validation into a sub-module where it would just handle that part of the resource generation. This part could be popped out into a smaller module outside of this current module, but we'll see what happens later.